### PR TITLE
fix: Replace backslash with forwardslash in template git path

### DIFF
--- a/src/commands/share/share.js
+++ b/src/commands/share/share.js
@@ -186,7 +186,7 @@ async function run(cmd) {
       repo.owner,
       repo.repo,
       repo.branch,
-      path.join(repo.root, name, repo.relativePath, repo.fileNames[0]),
+      path.join(repo.root, name, repo.relativePath, repo.fileNames[0]).replace(/\\/g, "/"),
       parser.stringify("yaml", sharedTemplate),
       true
     );


### PR DESCRIPTION
As path.join will use backslash on Windows causing issues in githubUtil.js which assumes forward slashes

**Issue #, if available:**
closes #5 

## Description of changes:

Using the same way of building the git path as in import.js and explore.js. This avoid issues with Windows paths using backslash.  

## Checklist

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [ ] Update docs

There are no tests around this part of the functionality so I've not added any additional ones, please let me know if you would like me to add some before merging

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
