### PR TITLE
fix: undefined filter param in explore command

### DIFF
--- a/src/shared/githubUtil.js
+++ b/src/shared/githubUtil.js
@@ -55,7 +55,7 @@ function sanitize(setting) {
   }
 }
 
-async function getPatterns(filter) {
+async function getPatterns(filter="") {
   const patternsList = [];
   let ownerName = "";
   for (const setting of settings.filter(p => (p.collectionName || p.owner + "/" + p.repo).toLowerCase().includes(filter.toLowerCase()))) {


### PR DESCRIPTION
**Issue, if available:**
N/A

## Description of changes:

Running `samp explore` throws this error:
```bash
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at /usr/local/lib/node_modules/samp-cli/src/shared/githubUtil.js:61:121
```
The `samp import` command uses the same function but it is passing [either an empty string or a source filter value.](https://github.com/ljacobsson/samp-cli/blob/bae27ab91ebfb8b8bbf09a6d9b0b8dcae4769760/src/commands/import/index.js#L9). Since explore right now only is used for exploring then I suggest my simple change of a default empty string parameter.

## Checklist

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [ ] Update docs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
