### PR TITLE
fix: make sure to pass the aws profile to IDE debug settings

### DIFF
--- a/src/commands/local/local.js
+++ b/src/commands/local/local.js
@@ -226,7 +226,7 @@ async function setupDebug(cmd) {
     const selectedFunctionsText = selectedFunctions.length === functionNames.length ? "all functions" : selectedFunctions.join(",");
     name = await inputUtil.text("Enter a name for the configuration", "Debug " + selectedFunctionsText);
     selectedFunctionsCsv = selectedFunctions.join(",")
-    args.push("--functions", selectedFunctionsCsv);
+    args.push("--functions", selectedFunctionsCsv, "--profile", profile);
   }
 
   const runtime = env.isNodeJS ? "nodejs" : env.functionLanguage;


### PR DESCRIPTION
## Description of changes:
When using `samp local --profile <your_profile>` the profile was not passed down to the generated IDE debug settings.

